### PR TITLE
feat: Add Ollama busy status indicator with timestamp-based filtering

### DIFF
--- a/backend/src/gateway.py
+++ b/backend/src/gateway.py
@@ -7,7 +7,8 @@ All inference happens locally - your queries never leave your machine.
 
 import asyncio
 from dataclasses import dataclass
-from typing import AsyncIterator
+from datetime import datetime, timedelta, timezone
+from typing import AsyncIterator, Optional
 
 import httpx
 
@@ -295,3 +296,65 @@ class InferenceGateway:
         """
         health = await self.health_check()
         return health.available_models
+
+    async def is_busy(self, since: Optional[datetime] = None) -> bool:
+        """
+        Check if Ollama is currently processing models from other requests.
+
+        Queries the /api/ps endpoint to see if any models are loaded.
+        If 'since' timestamp is provided, only considers models that were
+        loaded BEFORE that timestamp (i.e., from previous/other requests).
+
+        Args:
+            since: Optional timestamp. If provided, only count models loaded
+                   before this time as "busy" indicators. Models loaded after
+                   this time are assumed to be from the current operation.
+
+        Returns:
+            True if models from other requests are loaded, False otherwise.
+        """
+        try:
+            response = await self.client.get("/api/ps")
+            if response.status_code == 200:
+                data = response.json()
+                models = data.get("models", [])
+
+                if not since:
+                    # No timestamp filter - any loaded model means busy
+                    return len(models) > 0
+
+                # Ollama's default keep-alive is 5 minutes
+                # We'll use this to estimate when a model was loaded
+                keep_alive = timedelta(minutes=5)
+
+                for model in models:
+                    expires_at_str = model.get("expires_at")
+                    if not expires_at_str:
+                        continue
+
+                    try:
+                        # Parse ISO 8601 timestamp
+                        expires_at = datetime.fromisoformat(
+                            expires_at_str.replace("Z", "+00:00")
+                        )
+
+                        # Estimate when model was loaded
+                        # loaded_at ≈ expires_at - keep_alive
+                        loaded_at = expires_at - keep_alive
+
+                        # If model was loaded before 'since', it's from another request
+                        if loaded_at < since:
+                            return True
+
+                    except (ValueError, TypeError):
+                        # If we can't parse timestamp, be conservative and assume busy
+                        continue
+
+                # All models were loaded after 'since' or no valid timestamps
+                return False
+
+        except httpx.RequestError:
+            # If we can't connect, assume not busy (fail gracefully)
+            return False
+
+        return False

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -9,6 +9,7 @@ import logging
 import os
 import time
 from contextlib import asynccontextmanager
+from datetime import datetime
 from functools import wraps
 from pathlib import Path
 
@@ -220,6 +221,13 @@ class ListDeliberationsResponse(BaseModel):
 
     deliberation_ids: list[str]
     count: int
+
+
+class GatewayBusyResponse(BaseModel):
+    """Gateway busy status response."""
+
+    is_busy: bool
+    message: str
 
 
 # Endpoint guard decorators
@@ -485,6 +493,40 @@ async def list_models():
 
     models = await _gateway.list_models()
     return {"models": models}
+
+
+@app.get("/gateway/busy", response_model=GatewayBusyResponse)
+@require_initialized
+async def gateway_busy_status(since: str | None = None):
+    """
+    Check if the inference gateway is currently busy processing models.
+
+    If 'since' timestamp is provided, only models loaded BEFORE that time
+    are considered as "other requests". Models loaded after 'since' are
+    assumed to be from the current deliberation.
+
+    Args:
+        since: Optional ISO 8601 timestamp (e.g., from deliberation start).
+               If provided, filters out models loaded after this time.
+
+    Returns whether Ollama has models loaded from other/previous requests.
+    """
+    since_dt = None
+    if since:
+        try:
+            since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid 'since' timestamp format")
+
+    is_busy = await _gateway.is_busy(since=since_dt)
+
+    message = (
+        "Ollama is processing other requests"
+        if is_busy
+        else "Ollama is idle"
+    )
+
+    return GatewayBusyResponse(is_busy=is_busy, message=message)
 
 
 @app.get("/privacy/status")

--- a/frontend/src/app/components/council/council.component.html
+++ b/frontend/src/app/components/council/council.component.html
@@ -47,6 +47,7 @@
     [phase]="state().phase"
     [statusMessage]="state().statusMessage"
     [elapsedSeconds]="state().elapsedSeconds"
+    [ollamaBusy]="state().ollamaBusy"
     (cancel)="onCancel()"
   />
 }

--- a/frontend/src/app/components/loading-state/loading-state.component.html
+++ b/frontend/src/app/components/loading-state/loading-state.component.html
@@ -31,6 +31,15 @@
       </small>
     </div>
 
+    <!-- Ollama Busy Indicator -->
+    @if (ollamaBusy()) {
+      <div class="ollama-busy-notice">
+        <small class="text-info">
+          ⏳ Ollama is processing other requests
+        </small>
+      </div>
+    }
+
     <!-- Cancel Button -->
     <div class="cancel-actions">
       <button

--- a/frontend/src/app/components/loading-state/loading-state.component.ts
+++ b/frontend/src/app/components/loading-state/loading-state.component.ts
@@ -20,6 +20,9 @@ export class LoadingStateComponent {
   /** Elapsed time in seconds */
   readonly elapsedSeconds = input<number>(0);
 
+  /** Whether Ollama is busy processing other requests */
+  readonly ollamaBusy = input<boolean>(false);
+
   /** Emits when cancel is clicked */
   readonly cancel = output<void>();
 

--- a/frontend/src/app/models/index.ts
+++ b/frontend/src/app/models/index.ts
@@ -95,6 +95,11 @@ export interface HealthStatus {
   privacy_mode: string;
 }
 
+export interface GatewayBusyStatus {
+  is_busy: boolean;
+  message: string;
+}
+
 export type DeliberationPhase =
   | 'idle'
   | 'gathering'

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -6,6 +6,7 @@ import {
   Deliberation,
   HealthStatus,
   PrivacyStatus,
+  GatewayBusyStatus,
 } from '../models';
 
 const API_BASE = '/api';
@@ -40,6 +41,18 @@ export class ApiService {
   getPrivacyStatus(): Observable<PrivacyStatus> {
     return this.http
       .get<PrivacyStatus>(`${API_BASE}/privacy/status`)
+      .pipe(catchError(this.handleError));
+  }
+
+  getGatewayBusyStatus(since?: number): Observable<GatewayBusyStatus> {
+    let url = `${API_BASE}/gateway/busy`;
+    if (since) {
+      // Convert timestamp to ISO 8601 string
+      const sinceDate = new Date(since).toISOString();
+      url += `?since=${encodeURIComponent(sinceDate)}`;
+    }
+    return this.http
+      .get<GatewayBusyStatus>(url)
       .pipe(catchError(this.handleError));
   }
 

--- a/frontend/src/app/services/deliberation.service.ts
+++ b/frontend/src/app/services/deliberation.service.ts
@@ -10,6 +10,7 @@ export interface DeliberationState {
   error: string | null;
   startTime: number | null;
   elapsedSeconds: number;
+  ollamaBusy: boolean;
 }
 
 const initialState: DeliberationState = {
@@ -19,6 +20,7 @@ const initialState: DeliberationState = {
   error: null,
   startTime: null,
   elapsedSeconds: 0,
+  ollamaBusy: false,
 };
 
 @Injectable({
@@ -28,6 +30,7 @@ export class DeliberationService {
   private stateSubject = new ObjectStateSubject<DeliberationState>(initialState);
   state$ = this.stateSubject.$;
   private timerInterval: ReturnType<typeof setInterval> | null = null;
+  private busyPollingInterval: ReturnType<typeof setInterval> | null = null;
 
   constructor(private api: ApiService) {}
 
@@ -65,6 +68,7 @@ export class DeliberationService {
 
     // Start timer
     this.startTimer();
+    this.startBusyPolling();
 
     // Try streaming first
     this.api
@@ -85,6 +89,7 @@ export class DeliberationService {
       .subscribe({
         next: (deliberation) => {
           this.stopTimer();
+          this.stopBusyPolling();
           this.stateSubject.patch({
             phase: 'complete',
             statusMessage: 'Deliberation complete',
@@ -94,6 +99,7 @@ export class DeliberationService {
         },
         error: (err) => {
           this.stopTimer();
+          this.stopBusyPolling();
           this.setError(err.message || 'Deliberation failed');
         },
       });
@@ -150,12 +156,14 @@ export class DeliberationService {
   }
 
   reset(): void {
+    this.stopBusyPolling();
     this.stateSubject.resetToInitial();
   }
 
   cancel(): void {
     // Stop timer
     this.stopTimer();
+    this.stopBusyPolling();
 
     // Cancel API stream
     this.api.cancelStream();
@@ -194,6 +202,36 @@ export class DeliberationService {
     if (this.timerInterval) {
       clearInterval(this.timerInterval);
       this.timerInterval = null;
+    }
+  }
+
+  private startBusyPolling(): void {
+    this.stopBusyPolling(); // Clear any existing polling
+
+    // Delay first poll by 15 seconds to give current deliberation time to load models
+    // This prevents false positives from warmup models
+    setTimeout(() => {
+      // Poll every 8 seconds for Ollama busy status
+      this.busyPollingInterval = setInterval(() => {
+        const startTime = this.stateSubject.value.startTime;
+        this.api.getGatewayBusyStatus(startTime ?? undefined).subscribe({
+          next: (status) => {
+            this.stateSubject.patch({ ollamaBusy: status.is_busy });
+          },
+          error: (err) => {
+            // Silently fail - don't break deliberations if polling fails
+            console.warn('Failed to check Ollama busy status:', err);
+            this.stateSubject.patch({ ollamaBusy: false });
+          },
+        });
+      }, 8000); // 8 seconds interval
+    }, 15000); // Delay 15 seconds before starting to poll
+  }
+
+  private stopBusyPolling(): void {
+    if (this.busyPollingInterval) {
+      clearInterval(this.busyPollingInterval);
+      this.busyPollingInterval = null;
     }
   }
 }


### PR DESCRIPTION
## Summary

Implements a polling mechanism to detect when Ollama is processing other requests (e.g., from cancelled deliberations) and displays a user-friendly indicator during active deliberations.

This addresses issue #18 by informing users when delays are caused by previously cancelled requests still processing in Ollama.

## Key Features

- **Timestamp-based filtering**: Uses model `expires_at` timestamps from `/api/ps` to estimate load time
- **Smart detection**: Only flags models loaded BEFORE current deliberation started
- **15-second initial delay**: Prevents false positives from warmup models
- **Polling every 8 seconds**: Minimal overhead during deliberations
- **User-friendly message**: "⏳ Ollama is processing other requests" displayed in loading component
- **Graceful degradation**: Polling failures don't break deliberations

## Implementation Details

### Backend
- Added `is_busy(since)` method to `InferenceGateway` class
- Queries Ollama's `/api/ps` endpoint for loaded models
- Estimates model load time: `loaded_at ≈ expires_at - 5min` (Ollama's default keep-alive)
- Added `/gateway/busy` endpoint with optional `?since=<ISO8601>` query parameter

### Frontend
- Added polling mechanism in `DeliberationService` that starts/stops with deliberations
- Passes deliberation start timestamp to API for filtering
- Displays busy indicator in `LoadingStateComponent` between elapsed time and cancel button
- Silent error handling with console warnings

## Testing

### Backend Testing
```bash
# Without timestamp filter (any loaded model = busy)
curl "http://localhost:3000/api/gateway/busy"
# {"is_busy":true,"message":"Ollama is processing other requests"}

# With timestamp filtering (only models loaded before timestamp)
curl "http://localhost:3000/api/gateway/busy?since=2026-01-04T17:19:22Z"
# {"is_busy":false,"message":"Ollama is idle"}
```

### Browser Testing
- [x] Initial deliberation does NOT show false positive
- [x] Cancelled deliberation followed by new deliberation DOES show busy indicator
- [x] Polling stops when deliberation completes/fails/cancels
- [x] Hard refresh clears cached JavaScript

## Files Changed (8)

**Backend:**
- `backend/src/gateway.py` - `is_busy()` method with timestamp filtering
- `backend/src/main.py` - `/gateway/busy` endpoint

**Frontend:**
- `frontend/src/app/models/index.ts` - `GatewayBusyStatus` interface
- `frontend/src/app/services/api.service.ts` - `getGatewayBusyStatus()` method
- `frontend/src/app/services/deliberation.service.ts` - Polling mechanism
- `frontend/src/app/components/loading-state/loading-state.component.ts` - Input binding
- `frontend/src/app/components/loading-state/loading-state.component.html` - UI indicator
- `frontend/src/app/components/council/council.component.html` - State passing

## Related Issue

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)